### PR TITLE
fix: remove aggressive steering from tool descriptions

### DIFF
--- a/minimax_mcp/server.py
+++ b/minimax_mcp/server.py
@@ -40,9 +40,7 @@ api_client = MinimaxAPIClient(api_key, api_host)
 @mcp.tool(
     description="""
     
-    You MUST use this tool whenever you need to search for real-time or external information on the web.
-    
-    A web search API that works just like Google Search.
+    Search the web for real-time or external information. Works like Google Search.
     
     Args:
         query (str): The search query. Aim for 3-5 keywords for best results. For time-sensitive topics, include the current date (e.g. `latest iPhone 2025`).
@@ -104,10 +102,7 @@ def web_search(
 @mcp.tool(
     description="""
     
-    You MUST use this tool whenever you need to analyze, describe, or extract information from an image,
-    including when you get an image from user input or any task-related image.
-
-    An LLM-powered vision tool that can analyze and interpret image content from local files or URLs based on your instructions.
+    Analyze, describe, or extract information from an image using LLM-powered vision.
     Only JPEG, PNG, and WebP formats are supported. Other formats (e.g. PDF, GIF, PSD, SVG) are not supported.
 
     Args:


### PR DESCRIPTION
## Summary

Removes the `You MUST use this tool` directives from `web_search` and `understand_image` tool descriptions. These were introduced in #13 and violate the MCP convention that tool descriptions should describe capabilities, not dictate client agent behavior.

As noted in #14, tool descriptions should only describe what the tool does — it's the client agent's decision when to use them.

## Changes

- `web_search`: Replaced "You MUST use this tool whenever you need to search..." with "Search the web for real-time or external information."
- `understand_image`: Replaced "You MUST use this tool whenever you need to analyze..." with "Analyze, describe, or extract information from an image using LLM-powered vision."

All other description content (args, returns, search strategy, format notes) is unchanged.

Fixes #14