### PR TITLE
fix: compatibility with mcp>=2 / fastmcp>=3 (fixes #25)

### DIFF
--- a/minimax_mcp/__init__.py
+++ b/minimax_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Minimax Coding Plan MCP Server package."""
 
-__version__ = "0.0.3"
+__version__ = "0.1.0"

--- a/minimax_mcp/server.py
+++ b/minimax_mcp/server.py
@@ -14,7 +14,7 @@ Note: Tools without cost warnings are free to use as they only read existing dat
 import os
 import json
 from dotenv import load_dotenv
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from mcp.types import TextContent
 from minimax_mcp.utils import (
     process_image_url,
@@ -27,14 +27,13 @@ from minimax_mcp.client import MinimaxAPIClient
 load_dotenv()
 api_key = os.getenv(ENV_MINIMAX_API_KEY)
 api_host = os.getenv(ENV_MINIMAX_API_HOST)
-fastmcp_log_level = os.getenv(ENV_FASTMCP_LOG_LEVEL) or "WARNING"
 
 if not api_key:
     raise ValueError("MINIMAX_API_KEY environment variable is required")
 if not api_host:
     raise ValueError("MINIMAX_API_HOST environment variable is required")
 
-mcp = FastMCP("Minimax",log_level=fastmcp_log_level)
+mcp = FastMCP("Minimax")
 api_client = MinimaxAPIClient(api_key, api_host)
 
 @mcp.tool(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "minimax-coding-plan-mcp"
-version = "0.0.4"
+version = "0.1.0"
 description = "Specialized MiniMax Model Context Protocol (MCP) server designed for coding-plan users"
 authors = [
     { name = "Roy Wu", email = "zhengyu@minimax.chat" },
@@ -22,7 +22,8 @@ keywords = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.6.0",
+    "mcp>=1.6.0",
+    "fastmcp>=3.0",
     "python-dotenv>=1.0.1",
     "requests>=2.31.0",
 ]
@@ -34,7 +35,6 @@ minimax-coding-plan-mcp = "minimax_mcp.server:main"
 dev = [
     "pre-commit>=3.6.2",
     "ruff>=0.3.0",
-    "fastmcp>=0.4.1",
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
     "twine>=6.1.0",


### PR DESCRIPTION
## What

Fixes #25 — the package crashes on startup with
`ModuleNotFoundError: No module named 'mcp.server.fastmcp'` when installed
via `uvx` against `mcp>=2.0.0` (released 2026-07-28).

## Why

`mcp==2.0.0` removed the `mcp.server.fastmcp` submodule. The high-level
`FastMCP` decorator API (`@mcp.tool(...)`) was extracted out of `mcp` and
into the standalone [`fastmcp`](https://pypi.org/project/fastmcp/) PyPI
package as of fastmcp 2.x. The repo's `pyproject.toml` accidentally
listed `fastmcp` as a *dev* extra only, so the runtime import had no
fallback on `mcp>=2` — that is the actual root cause, not just a missing
upper bound.

## Diff

`minimax_mcp/server.py`
```diff
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
@@
-fastmcp_log_level = os.getenv(ENV_FASTMCP_LOG_LEVEL) or "WARNING"
@@
-mcp = FastMCP("Minimax", log_level=fastmcp_log_level)
+mcp = FastMCP("Minimax")
```

`pyproject.toml`
```diff
 dependencies = [
-    "mcp[cli]>=1.6.0",
+    "mcp>=1.6.0",
+    "fastmcp>=3.0",
     "python-dotenv>=1.0.1",
     "requests>=2.31.0",
 ]
```

`minimax_mcp/__init__.py` bumps `__version__` to `0.1.0`.

Total: **+6 / -7 across 3 files**.

## Verification

End-to-end against the live MiniMax API with a fresh uvx-resolved env:

- `MCP initialize` → `server='Minimax' version='3.4.6' protocol='2025-11-25'`
- `tools/list` → `['understand_image', 'web_search']`
- `web_search('MiniMax M3 model release date')` → 9 organic results, `base_resp.status_code=0`
- `understand_image('https://httpbin.org/image/png')` → correctly described as "round, pink cartoon pig face"

Resolved env: `mcp==1.29.0`, `fastmcp==3.4.6`.

## Pinning note

Pinning `fastmcp>=3.0` raises the effective floor above what 0.0.4
required (`fastmcp` was a dev-only extra so effectively zero). This is
intentional: the alternative — keeping `from mcp.server.fastmcp import
FastMCP` — is literally impossible, since that module was deleted in
`mcp==2.0.0`. If you'd prefer a lower floor, I can target
`fastmcp>=2,<3` instead; that line still accepts the legacy
`log_level=` constructor kwarg, so `server.py` becomes a single-line
change and the dropped-kwarg part of the diff goes away.

Version bump is `0.0.4 → 0.1.0`; happy to mark it `0.0.5` if you'd
prefer semver-strict.

---

Reported-by: @LelouchOTR
Tested-by: @LelouchOTR
Refs: #25

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/MiniMax-Coding-Plan-MCP/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788648759&installation_model_id=427615&pr_number=27&repository=MiniMax-AI%2FMiniMax-Coding-Plan-MCP&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2FMiniMax-Coding-Plan-MCP%2Fpull%2F27&signature=eb197ba12fe9baa3c22bbb7a069cde39638f034548380934d5f72cb8b529b325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->